### PR TITLE
Updated fstab applet

### DIFF
--- a/diskmanagement/fstab_manager.py
+++ b/diskmanagement/fstab_manager.py
@@ -10,33 +10,53 @@ from prompt_toolkit.widgets import Frame
 from prompt_toolkit.layout.containers import HSplit, Window
 from prompt_toolkit.formatted_text import FormattedText
 from prompt_toolkit.layout.controls import FormattedTextControl
+from prompt_toolkit.styles import Style
 import asyncio
 font = Ansi.escape
 
 def run_fstab_menu():
     asyncio.run(run_fstab_menu_async())
 
-def build_lines(disks, fstab_uuids, selected_index):
+def build_lines(disks, fstab_uuids, selected_index, mounted_disks):
+    # Determine column widths
+    mount_width = max(len(d["mount"]) for d in disks) if disks else 10
+    size_width = max(len(d["size"]) for d in disks) if disks else 10
+    uuid_width = max(len(d["uuid"]) for d in disks) if disks else 10
+
     lines = []
     for i, disk in enumerate(disks):
         checked = "[x]" if disk["uuid"] in fstab_uuids else "[ ]"
         pointer = "=> " if i == selected_index else "   "
-        line = f"{pointer}{checked} {disk['mount']} ({disk['size']}) UUID={disk['uuid']}"
-        style = "class:highlight" if i == selected_index else ""
+        connected = disk["uuid"] in mounted_disks
+        status = "" if connected else " (not connected)"
+
+        # Format each column with padding
+        mount = disk["mount"].ljust(mount_width)
+        size = disk["size"].rjust(size_width)
+        uuid = disk["uuid"].ljust(uuid_width)
+
+        line = f"{pointer}{checked} {mount}  {size}  UUID={uuid}{status}"
+        style = "class:highlight" if i == selected_index else "class:dim" if not connected else ""
         lines.append((style, line + "\n"))
+
     return FormattedText(lines)
 
 async def run_fstab_menu_async():
-    disks = get_mounted_disks()
-    fstab_uuids = get_fstab_uuids()
+    mounted_disks = get_mounted_disks()
+    fstab_entries = get_fstab_entries()
+
+    # Merge fstab entries with mounted disks (mounted takes precedence)
+    all_disks = {**fstab_entries, **mounted_disks}  # mounted_disks overrides same UUIDs
+    disks = list(all_disks.values())
+    fstab_uuids = set(fstab_entries.keys())
     selected = [0]
 
     def get_display_text():
-        return build_lines(disks, fstab_uuids, selected[0])
+        return build_lines(disks, fstab_uuids, selected[0], mounted_disks)
 
     text_control = FormattedTextControl(get_display_text, focusable=True)
     disk_window = Window(content=text_control, always_hide_cursor=True)
-    footer = Window(height=1, content=FormattedTextControl("Press (space) to toggle or q to quit"))
+    footer = Window(height=1, content=FormattedTextControl("Use ↑/↓ to navigate, (space) to toggle, q to quit"))
 
     root_container = HSplit([disk_window, footer])
     body = Frame(root_container, title="FSTAB Manager")
@@ -58,31 +78,56 @@ async def run_fstab_menu_async():
         mount = disk["mount"]
         present = uuid in fstab_uuids
         toggle_fstab_entry(uuid, mount, present)
+        # Re-read fstab UUIDs after toggle
         fstab_uuids.clear()
-        fstab_uuids.update(get_fstab_uuids())
+        fstab_uuids.update(get_fstab_entries().keys())
 
     @kb.add("q")
     @kb.add("escape")
     def exit_app(event):
         event.app.exit()
 
-    app = Application(layout=Layout(body), key_bindings=kb, full_screen=True)
+    style = Style.from_dict({
+        "highlight": "bold underline",
+        "dim": "fg:#888888",
+    })
+
+    app = Application(
+        layout=Layout(body),
+        key_bindings=kb,
+        full_screen=True,
+        style=style
+    )
     await app.run_async()
 
 def get_mounted_disks():
     result = subprocess.run(['lsblk', '-b', '-o', 'MOUNTPOINT,UUID,SIZE'], capture_output=True, text=True)
-    disks = []
+    disks = {}
     for line in result.stdout.splitlines()[1:]:
         parts = line.strip().split(None, 2)
         if len(parts) == 3:
             mount, uuid, size = parts
-            if mount.startswith("/mnt/") and uuid != "":
-                disks.append({
-                    "mount": mount,
+            if uuid:  # Only process entries with UUIDs
+                disks[uuid] = {
+                    "mount": mount if mount else "unknown",
                     "uuid": uuid,
-                    "size": format_size(int(size))
-                })
+                    "size": format_size(int(size)) if size.isdigit() else "unknown"
+                }
     return disks
+
+def get_fstab_entries():
+    entries = {}
+    if os.path.exists(FSTAB_PATH):
+        with open(FSTAB_PATH) as f:
+            for line in f:
+                line = line.strip()
+                if line.startswith("UUID="):
+                    parts = line.split()
+                    if len(parts) >= 2:
+                        uuid = parts[0].split("=")[1]
+                        mount = parts[1]
+                        entries[uuid] = {"uuid": uuid, "mount": mount, "size": "not connected"}
+    return entries
 
 def toggle_fstab_entry(uuid, mount, present):
     lines = []

--- a/diskmanagement/fstab_manager.py
+++ b/diskmanagement/fstab_manager.py
@@ -107,9 +107,9 @@ def get_mounted_disks():
         parts = line.strip().split(None, 2)
         if len(parts) == 3:
             mount, uuid, size = parts
-            if uuid:  # Only process entries with UUIDs
+            if mount and mount.startswith("/mnt/") and uuid:
                 disks[uuid] = {
-                    "mount": mount if mount else "unknown",
+                    "mount": mount,
                     "uuid": uuid,
                     "size": format_size(int(size)) if size.isdigit() else "unknown"
                 }

--- a/diskmanagement/fstab_manager.py
+++ b/diskmanagement/fstab_manager.py
@@ -126,8 +126,14 @@ def get_fstab_entries():
                     if len(parts) >= 2:
                         uuid = parts[0].split("=")[1]
                         mount = parts[1]
-                        entries[uuid] = {"uuid": uuid, "mount": mount, "size": "not connected"}
+                        if mount.startswith("/mnt/"):
+                            entries[uuid] = {
+                                "uuid": uuid,
+                                "mount": mount,
+                                "size": "not connected"
+                            }
     return entries
+
 
 def toggle_fstab_entry(uuid, mount, present):
     lines = []

--- a/diskmanagement/fstab_manager.py
+++ b/diskmanagement/fstab_manager.py
@@ -36,7 +36,7 @@ def build_lines(disks, fstab_uuids, selected_index, mounted_disks):
         uuid = disk["uuid"].ljust(uuid_width)
 
         line = f"{pointer}{checked} {mount}  {size}  UUID={uuid}{status}"
-        style = "class:highlight" if i == selected_index else "class:dim" if not connected else ""
+        style = "class:highlight" if i == selected_index else "class:dim" if not connected else "class:normal"
         lines.append((style, line + "\n"))
 
     return FormattedText(lines)

--- a/diskmanagement/fstab_manager.py
+++ b/diskmanagement/fstab_manager.py
@@ -47,7 +47,7 @@ async def run_fstab_menu_async():
 
     # Merge fstab entries with mounted disks (mounted takes precedence)
     all_disks = {**fstab_entries, **mounted_disks}  # mounted_disks overrides same UUIDs
-    disks = list(all_disks.values())
+    disks = sorted(all_disks.values(), key=lambda disk: disk.get("mount", ""))
     fstab_uuids = set(fstab_entries.keys())
     selected = [0]
 


### PR DESCRIPTION
The fstab applet now displays the entries if the disk isn't mounted

Pressing space will toggle the entry by commenting not removing it
Pressing r will remove the entry by removing it

It indicates if the disk is connected or not